### PR TITLE
在biliplus API中添加access_key参数，使海外用户可以播放番剧

### DIFF
--- a/plugin.video.bilibili/resources/language/Chinese (Simple)/strings.po
+++ b/plugin.video.bilibili/resources/language/Chinese (Simple)/strings.po
@@ -82,3 +82,20 @@ msgstr "启用内置弹幕功能"
 msgctxt "#32203"
 msgid "damakufolder"
 msgstr "设置弹幕缓存文件夹"
+
+
+msgctxt "#32301"
+msgid "API Setting"
+msgstr "API设置"
+
+msgctxt "#32302"
+msgid "BiliPlus"
+msgstr "BiliPlus"
+
+msgctxt "#32303"
+msgid "accesskeyswitch"
+msgstr "使用此access_key访问需要用户权限的操作"
+
+msgctxt "#32304"
+msgid "accesskey"
+msgstr "access_key"

--- a/plugin.video.bilibili/resources/settings.xml
+++ b/plugin.video.bilibili/resources/settings.xml
@@ -29,4 +29,10 @@
     <setting label="32202" type="bool" id="damakustatus" default="false"/>
     <setting label="32203" type="folder" id="damakufolder" source="auto" option="writeable"/>
     </category>  
+
+    <category label="32301">
+    <setting label="32302" type="lsep"/>
+    <setting label="32303" type="bool" id="accesskeyswitch" default="false"/>
+    <setting id="accesskey" type="text" label="32304" default=""/>
+    </category>
 </settings>


### PR DESCRIPTION
# plugin.video.bilibili

## settings.xml & strings.po
- Add a setting to let the user set up the access_key parameter for biliplus API.
- 和SESSDATA类似，添加一个biliplus API access_key的设置

## addon.py
- Add a try-except block to avoid an exception for oversea users.
- 海外用户无法使用现有逻辑获取番剧视频清晰度列表，加了一个try block
- Add some logics to use biliplus API to play anime for oversea users.
- 在def play()里面，如果番剧视频清晰度列表为空，则认定是海外用户，使用biliplus API播放番剧
- 在def get_api4()里面，如果用户设置了access_key，则添加它到query string里面